### PR TITLE
feat: add Credential test for api key

### DIFF
--- a/credentials/PeliqanApi.credentials.ts
+++ b/credentials/PeliqanApi.credentials.ts
@@ -1,5 +1,6 @@
 import {
 	IAuthenticateGeneric,
+	ICredentialTestRequest,
 	ICredentialType,
 	INodeProperties,
 } from 'n8n-workflow';
@@ -16,6 +17,12 @@ export class PeliqanApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'Domain',
+			name: 'domain',
+			type: 'string',
+			default: 'https://app.eu.peliqan.io',		
+		}
 	];
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
@@ -23,6 +30,13 @@ export class PeliqanApi implements ICredentialType {
 			headers: {
 				'Authorization': '={{"JWT " + $credentials.apiKey}}',
 			}
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials.domain}}',
+			url: '/api/applications',
 		},
 	};
 }


### PR DESCRIPTION
Add automatic test of api key before being saved in n8n.